### PR TITLE
ExpressoMail: Algumas imagens no corpo do e-mail não são renderizadas

### DIFF
--- a/expressoMail1_2/inc/class.exporteml.inc.php
+++ b/expressoMail1_2/inc/class.exporteml.inc.php
@@ -576,8 +576,8 @@ function export_all($params){
 		  	return str_replace( $array1, $array2, $string );
 		*/
 		return strtr($string,
-			"áàâãäéèêëíìîïóòôõöúùûüç?\"'!@#$%¨&*()-=+´`[]{}~^,<>;:/?\\|¹²³£¢¬§ªº°ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇ",
-			"aaaaaeeeeiiiiooooouuuuc___________________________________________AAAAAEEEEIIIIOOOOOUUUUC");
+			"áàâãäéèêëíìîïóòôõöúùûüç?\"'!@#$%¨&*()=+´`[]{}~^,<>;:/?\\|¹²³£¢¬§ªº°ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇ",
+			"aaaaaeeeeiiiiooooouuuuc__________________________________________AAAAAEEEEIIIIOOOOOUUUUC");
         }
 
 	function get_attachments_headers( $folder, $id_number ){

--- a/expressoMail1_2/inc/class.imap_functions.inc.php
+++ b/expressoMail1_2/inc/class.imap_functions.inc.php
@@ -2049,7 +2049,7 @@ class imap_functions
 		// Trata urls do tipo aaaa.bbb.empresa  
 		// Usadas na intranet. 
 
-		$pattern = '/(background-image\:url\()?(?<=[\s|(<br>)|\n|\r|;])(((http|https|ftp|ftps)?:\/\/((?:[\w]\.?)+(?::[\d]+)?[:\/.\-~&=?%;@#,+\w]*))|((?:www?\.)(?:\w\.?)*(?::\d+)?[\:\/\w.\-~&=?%;@+]*))/i';   
+		$pattern = '/[^(background-image\:url\()?](?<=[\s|(<br>)|\n|\r|;])(((http|https|ftp|ftps)?:\/\/((?:[\w]\.?)+(?::[\d]+)?[:\/.\-~&=?%;@#,+\w]*))|((?:www?\.)(?:\w\.?)*(?::\d+)?[\:\/\w.\-~&=?%;@+]*))/i';   
        
 		$body = preg_replace_callback($pattern,array( &$this, 'replace_links_callback'), $body);
 


### PR DESCRIPTION
Foi identificado um problema de expressão regular que adicionava uma tag &lt;a&gt; dentro de um css inline, na regra background-image, fazendo com que a imagem não fosse renderizada. Após ajustes na expressão regular, as imagens no corpo do e-mail renderizam normalmente.
