### PR TITLE
ExpressoAdmin: Listas de email não são exibidas ao editar um usuário

### DIFF
--- a/expressoAdmin1_2/inc/class.ldap_functions.inc.php
+++ b/expressoAdmin1_2/inc/class.ldap_functions.inc.php
@@ -1288,24 +1288,22 @@ class ldap_functions
 			
 	function get_available_maillists($params)
 	{
-		if ( !$ldapMasterConnect = $this->ldapMasterConnect() )
-			return false;
-			
-		$context = $params['context'];
-		$justthese = array("uid","mail","uidNumber");
-                $maillists=ldap_list($ldapMasterConnect, $context, ("(phpgwAccountType=l)"), $justthese);
-                ldap_sort($ldapMasterConnect, $maillists, "uid");
-		
-                $entries = ldap_get_entries($ldapMasterConnect, $maillists);
-			
-		$options = '';			
-		for ($i=0; $i<$entries['count']; ++$i)
-			{
-			$options .= "<option value=" . $entries[$i]['uid'][0] . ">" . $entries[$i]['uid'][0] . " (" . $entries[$i]['mail'][0] . ")" . "</option>";
-		}
-		
-    	ldap_close($ldapMasterConnect);
-   		return $options;
+            $options = '';
+            $context = $params['context'];
+
+            //Exibe todas as listas
+            if (empty($params['sentence']))
+            {
+                    $params['sentence'] = '.';                       
+            }
+            $maillists_info = $this->functions->get_list('maillists', $params['sentence'],(array) $context);
+
+            foreach ($maillists_info as $maillist) 
+            {
+                $options .= "<option value=" . $maillist['uid'] . ">" . $maillist['uid'] . " (" . $maillist['email'] . ")" . "</option>";
+            }
+
+            return $options;
 	}
 
         function get_available_institutional_account($params)

--- a/expressoMail1_2/inc/class.exporteml.inc.php
+++ b/expressoMail1_2/inc/class.exporteml.inc.php
@@ -576,8 +576,8 @@ function export_all($params){
 		  	return str_replace( $array1, $array2, $string );
 		*/
 		return strtr($string,
-			"áàâãäéèêëíìîïóòôõöúùûüç?\"'!@#$%¨&*()-=+´`[]{}~^,<>;:/?\\|¹²³£¢¬§ªº°ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇ",
-			"aaaaaeeeeiiiiooooouuuuc___________________________________________AAAAAEEEEIIIIOOOOOUUUUC");
+			"áàâãäéèêëíìîïóòôõöúùûüç?\"'!@#$%¨&*()=+´`[]{}~^,<>;:/?\\|¹²³£¢¬§ªº°ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇ",
+			"aaaaaeeeeiiiiooooouuuuc__________________________________________AAAAAEEEEIIIIOOOOOUUUUC");
         }
 
 	function get_attachments_headers( $folder, $id_number ){


### PR DESCRIPTION
Ao filtrar as listas de e-mail de um determinado usuário, nenhuma lista era exibida. 

O problema estava na função nativa do PHP `ldap_list()` que retornava **false**. A chamada deste filtro foi igualada a que já era executada na página que contém a listagem de listas de e-mail.
