### PR TITLE
PHPGWAPI: Remover o link de ajuda ao desativar a aplicação Help

### DIFF
--- a/expressoMail1_2/inc/class.exporteml.inc.php
+++ b/expressoMail1_2/inc/class.exporteml.inc.php
@@ -576,8 +576,8 @@ function export_all($params){
 		  	return str_replace( $array1, $array2, $string );
 		*/
 		return strtr($string,
-			"áàâãäéèêëíìîïóòôõöúùûüç?\"'!@#$%¨&*()-=+´`[]{}~^,<>;:/?\\|¹²³£¢¬§ªº°ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇ",
-			"aaaaaeeeeiiiiooooouuuuc___________________________________________AAAAAEEEEIIIIOOOOOUUUUC");
+			"áàâãäéèêëíìîïóòôõöúùûüç?\"'!@#$%¨&*()=+´`[]{}~^,<>;:/?\\|¹²³£¢¬§ªº°ÁÀÂÃÄÉÈÊËÍÌÎÏÓÒÔÕÖÚÙÛÜÇ",
+			"aaaaaeeeeiiiiooooouuuuc__________________________________________AAAAAEEEEIIIIOOOOOUUUUC");
         }
 
 	function get_attachments_headers( $folder, $id_number ){

--- a/phpgwapi/inc/class.common.inc.php
+++ b/phpgwapi/inc/class.common.inc.php
@@ -1140,7 +1140,11 @@
 					$GLOBALS['phpgw_info']['navbar'][$app]['title'] = $GLOBALS['phpgw_info']['apps'][$app]['title'];
 					$GLOBALS['phpgw_info']['navbar'][$app]['url']   = $GLOBALS['phpgw']->link('/' . $app . '/index.php',$GLOBALS['phpgw_info']['flags']['params'][$app]);
 					$GLOBALS['phpgw_info']['navbar'][$app]['name']  = $app;
-
+                                        
+                                        //Add 'status' and 'enabled' to global navbar
+                                        $GLOBALS['phpgw_info']['navbar'][$app]['enabled'] = $data['enabled'];
+                                        $GLOBALS['phpgw_info']['navbar'][$app]['status']  = $data['status'];
+                                        
 					// create popup target
 					if ($data['status'] == 4)
 					{

--- a/phpgwapi/templates/classic/navbar.inc.php
+++ b/phpgwapi/templates/classic/navbar.inc.php
@@ -29,13 +29,12 @@
 		$GLOBALS['celepar_tpl']->set_block('navbar','sidebox_hide_footer','sidebox_hide_footer');
 		$GLOBALS['celepar_tpl']->set_block('navbar','appbox','appbox');
 		$GLOBALS['celepar_tpl']->set_block('navbar','navbar_footer','navbar_footer');
+                $GLOBALS['celepar_tpl']->set_block('navbar','help_link_block','help_link_block');
 		
 	        $GLOBALS['celepar_tpl']->set_var('my_preferences', lang("My Preferences"));
                 $GLOBALS['celepar_tpl']->set_var('title_my_preferences', lang("Click here to change your Expresso password and other preferences"));
                 $GLOBALS['celepar_tpl']->set_var('title_suggestions', lang("Send your critics, doubts or suggestions"));
                 $GLOBALS['celepar_tpl']->set_var('suggestions', lang("Suggestions"));
-                $GLOBALS['celepar_tpl']->set_var('help', lang("Help"));
-                $GLOBALS['celepar_tpl']->set_var('title_help', lang("Click here for help"));
 
 		$var['img_root'] = $GLOBALS['phpgw_info']['server']['webserver_url'] . '/phpgwapi/templates/celepar/images';
 		$var['dir_root'] = $GLOBALS['phpgw_info']['server']['webserver_url'];
@@ -64,8 +63,24 @@
 		
 		$i = 0;
 		foreach($GLOBALS['phpgw_info']['navbar'] as $app => $app_data)
-		{
-			
+		{                   
+                                if($app == 'help')
+                                {
+                                    if($app_data['status'] != 0 && $app_data['enabled'] == true )
+                                    {
+
+                                        $GLOBALS['celepar_tpl']->set_var('help', lang("Help"));
+                                        $GLOBALS['celepar_tpl']->set_var('title_help', lang("Click here for help"));
+                                        $GLOBALS['celepar_tpl']->parse('help_link','help_link_block');
+
+                                    }
+                                }
+
+                                if($app_data['enabled'] == false || $app_data['status'] == 0)
+                                {
+                                    continue;
+                                }
+                                
 				if($app != 'preferences' && $app != 'about' && $app != 'logout')
 				{
 					$title = $GLOBALS['phpgw_info']['apps'][$app]['title'];

--- a/phpgwapi/templates/classic/navbar.tpl
+++ b/phpgwapi/templates/classic/navbar.tpl
@@ -72,11 +72,11 @@
   <td width="30%" align="left" id="user_info" nowrap>{user_info}{frontend_name}</td>
   <td width="30%" id="admin_info" nowrap>{current_users}</td>
   <td style="padding-right:10px" width="*" align="right" valign="center" nowrap="true">
-  		<a href="{dir_root}/preferences" title="{title_my_preferences}" alt="{title_my_preferences}" onmouseover="javascript:self.status='{title_my_preferences}'" onmouseout="javascript:self.status=''"><img height="15px" src="{dir_root}/phpgwapi/templates/celepar/images/preferences.png"><font size="-1">{my_preferences}</font></a>
-  		&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-  		<a href="#" title="{title_suggestions}" alt="{title_suggestions}" onmouseover="javascript:self.status='{title_suggestions}'" onmouseout="javascript:self.status=''" onclick="javascript:openWindow(400,550,'{dir_root}/help/enviasugestao.php')"><img src="{dir_root}/phpgwapi/templates/celepar/images/criticas.jpg"><font size="-1">{suggestions}</font></a>
-  		&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-  		<a href="#" title="{title_help}" alt="{title_help}" onmouseover="javascript:self.status='{title_help}'" onmouseout="javascript:self.status=''" onclick="javascript:openWindow(480,510,'{dir_root}/help')"><img src="{dir_root}/phpgwapi/templates/celepar/images/ajuda.jpg"><font size="-1">{help}</font></a>
+    <a href="{dir_root}/preferences" title="{title_my_preferences}" alt="{title_my_preferences}" onmouseover="javascript:self.status='{title_my_preferences}'" onmouseout="javascript:self.status=''"><img height="15px" src="{dir_root}/phpgwapi/templates/celepar/images/preferences.png"><font size="-1">{my_preferences}</font></a>
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+    <a href="#" title="{title_suggestions}" alt="{title_suggestions}" onmouseover="javascript:self.status='{title_suggestions}'" onmouseout="javascript:self.status=''" onclick="javascript:openWindow(400,550,'{dir_root}/help/enviasugestao.php')"><img src="{dir_root}/phpgwapi/templates/celepar/images/criticas.jpg"><font size="-1">{suggestions}</font></a>
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+    {help_link}
   </td>
  </tr>
 </table>
@@ -92,6 +92,11 @@
   }	
 </script>
 <!-- END navbar_header -->
+
+<!-- BEGIN help_link_block -->
+    <a href="#" title="{title_help}" alt="{title_help}" onmouseover="javascript:self.status='{title_help}'" onmouseout="javascript:self.status=''" onclick="javascript:openWindow(480,510,'{dir_root}/help/')"><img src="{dir_root}/phpgwapi/templates/{template}/images/help.png" width="16px"><font id="links_bar">{help}</font></a>
+<!-- END help_link_block -->
+
 <!-- BEGIN appbox -->	
 	<div id="divSubContainer">
 		<table width="100%" cellspacing="0" cellpadding="0" border="0">

--- a/phpgwapi/templates/default/navbar.inc.php
+++ b/phpgwapi/templates/default/navbar.inc.php
@@ -29,13 +29,12 @@
 		$GLOBALS['celepar_tpl']->set_block('navbar','sidebox_hide_footer','sidebox_hide_footer');
 		$GLOBALS['celepar_tpl']->set_block('navbar','appbox','appbox');
 		$GLOBALS['celepar_tpl']->set_block('navbar','navbar_footer','navbar_footer');
-		
+		$GLOBALS['celepar_tpl']->set_block('navbar','help_link_block','help_link_block');
+                
 	        $GLOBALS['celepar_tpl']->set_var('my_preferences', lang("My Preferences"));
                 $GLOBALS['celepar_tpl']->set_var('title_my_preferences', lang("Click here to change your Expresso password and other preferences"));
                 $GLOBALS['celepar_tpl']->set_var('title_suggestions', lang("Send your critics, doubts or suggestions"));
                 $GLOBALS['celepar_tpl']->set_var('suggestions', lang("Suggestions"));
-                $GLOBALS['celepar_tpl']->set_var('help', lang("Help"));
-		$GLOBALS['celepar_tpl']->set_var('title_help', lang("Click here for help"));
 		$GLOBALS['celepar_tpl']->set_var('template',$GLOBALS['phpgw_info']['server']['template_set']);
 
 		$var['img_root'] = $GLOBALS['phpgw_info']['server']['webserver_url'] . '/phpgwapi/templates/'.$GLOBALS['phpgw_info']['server']['template_set'].'/images';
@@ -58,7 +57,26 @@
 		
 		$i = 0;
 		foreach($GLOBALS['phpgw_info']['navbar'] as $app => $app_data)
-		{
+		{       
+                        if($app == 'help')
+                        {
+                          
+                          if($app_data['status'] != 0 && $app_data['enabled'] == true )
+                          {
+                              
+                            $GLOBALS['celepar_tpl']->set_var('help', lang("Help"));
+                            $GLOBALS['celepar_tpl']->set_var('title_help', lang("Click here for help"));
+                            $GLOBALS['celepar_tpl']->parse('help_link','help_link_block');
+                            
+                          }
+
+                        }
+                  
+                        if($app_data['enabled'] == false || $app_data['status'] == 0)
+                        {
+                            continue;
+                        }
+                        
 			$current_app = False;
 				if($app != 'preferences' && $app != 'about' && $app != 'logout')
 				{

--- a/phpgwapi/templates/default/navbar.tpl
+++ b/phpgwapi/templates/default/navbar.tpl
@@ -98,11 +98,11 @@ function zoom_out(id)
   <td width="30%" align="left" id="user_info" nowrap>{user_info}{frontend_name}</td>
   <td width="30%" id="admin_info" nowrap>{current_users}</td>
   <td style="padding-right:10px" width="*" align="right" valign="center" nowrap="true">
-  		<a href="{dir_root}/preferences/" title="{title_my_preferences}" alt="{title_my_preferences}" onmouseover="javascript:self.status='{title_my_preferences}'" onmouseout="javascript:self.status=''"><img height="15px" src="{dir_root}/phpgwapi/templates/{template}/images/preferences.png"><font id="links_bar">{my_preferences}</font></a>
-  		&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-  		<a href="#" title="{title_suggestions}" alt="{title_suggestions}" onmouseover="javascript:self.status='{title_suggestions}'" onmouseout="javascript:self.status=''" onclick="javascript:openWindow(400,550,'{dir_root}/help/enviasugestao.php')"><img src="{dir_root}/phpgwapi/templates/{template}/images/critic.png"><font id="links_bar">{suggestions}</font></a>
-  		&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-  		<a href="#" title="{title_help}" alt="{title_help}" onmouseover="javascript:self.status='{title_help}'" onmouseout="javascript:self.status=''" onclick="javascript:openWindow(480,510,'{dir_root}/help/')"><img src="{dir_root}/phpgwapi/templates/{template}/images/help.png" width="16px"><font id="links_bar">{help}</font></a>
+    <a href="{dir_root}/preferences/" title="{title_my_preferences}" alt="{title_my_preferences}" onmouseover="javascript:self.status='{title_my_preferences}'" onmouseout="javascript:self.status=''"><img height="15px" src="{dir_root}/phpgwapi/templates/{template}/images/preferences.png"><font id="links_bar">{my_preferences}</font></a>
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+    <a href="#" title="{title_suggestions}" alt="{title_suggestions}" onmouseover="javascript:self.status='{title_suggestions}'" onmouseout="javascript:self.status=''" onclick="javascript:openWindow(400,550,'{dir_root}/help/enviasugestao.php')"><img src="{dir_root}/phpgwapi/templates/{template}/images/critic.png"><font id="links_bar">{suggestions}</font></a>
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+    {help_link}
   </td>
  </tr>
 </table>
@@ -120,6 +120,11 @@ function zoom_out(id)
   }	
 </script>
 <!-- END navbar_header -->
+
+<!-- BEGIN help_link_block -->
+    <a href="#" title="{title_help}" alt="{title_help}" onmouseover="javascript:self.status='{title_help}'" onmouseout="javascript:self.status=''" onclick="javascript:openWindow(480,510,'{dir_root}/help/')"><img src="{dir_root}/phpgwapi/templates/{template}/images/help.png" width="16px"><font id="links_bar">{help}</font></a>
+<!-- END help_link_block -->
+
 <!-- BEGIN appbox -->	
 	<div id="divSubContainer">
 		<table width="100%" cellspacing="0" cellpadding="0" border="0">


### PR DESCRIPTION
Adicionada funcionalidade de "esconder" o link de ajuda, localizado no canto superior direito, ao desativar a aplicação **Help**. Observe as imagens abaixo:
## 1. Desabilitar a aplicação de Ajuda

![help-disable-link-first](https://f.cloud.github.com/assets/431606/1815508/e91640a6-6f1a-11e3-8981-008e89ed1f3e.png)
## 2. Link de ajuda será ocultado

![help-disable-link-second](https://f.cloud.github.com/assets/431606/1815599/33ca8b0e-6f1e-11e3-93c3-22500d372ac0.png)
